### PR TITLE
Fixed a potential race condition before assigning FIP

### DIFF
--- a/templates/singleServerIPv6withFWaaSv1/ubuntu_server_dualstack.yaml
+++ b/templates/singleServerIPv6withFWaaSv1/ubuntu_server_dualstack.yaml
@@ -93,6 +93,9 @@ resources:
 
   dualstack_fip:
     type: OS::Neutron::FloatingIP
+    depends_on:
+      - dualstack_router
+      - ipv4_router_interface  # Important, since otherwise there is no connection to provider_network yet
     properties:
       floating_network: { get_param: provider_network }
       port_id: { get_resource: dualstack_server_port }


### PR DESCRIPTION
The race condition didn't trigger all the time, but some times, stack
creation didn't work because of this with an weird error.

```
017-11-30 13:17:26Z [ipv6-test.dualstack_fip]: CREATE_FAILED  NotFound:
resources.dualstack_fip: External network
54258498-a513-47da-9369-1a644e4be692 is not reachable from subnet
d2c7214f-3b50-499c-ac50-a49ad668b88d.  Therefore, cannot associate Port
f3de996f-3d74-4d33-9224-7c47cd9cedb7 with a Floating IP.
Neutron

2017-11-30 13:17:26Z [ipv6-test]: CREATE_FAILED  Resource CREATE failed:
NotFound: resources.dualstack_fip: External network
54258498-a513-47da-9369-1a644e4be692 is not reachable from subnet
d2c7214f-3b50-499c-ac50-a49ad668b88d.  Therefore, cannot associate Port
f3de996f-3d74-4d33-9224-7c47cd9cedb7 with
```