### PR TITLE
Fix asset link that got broken because of repository change.

### DIFF
--- a/heat/templates/multiServerIPv6withLBaaSv2/_lb_member.yaml
+++ b/heat/templates/multiServerIPv6withLBaaSv2/_lb_member.yaml
@@ -75,7 +75,7 @@ resources:
             After=network.target
             [Service]
             Type=simple
-            ExecStartPre=/bin/bash -c '/usr/bin/test -f /usr/local/bin/whoamI || /usr/bin/curl -Lo /usr/local/bin/whoamI https://github.com/emilevauge/whoamI/releases/download/1.1.0/whoamI'
+            ExecStartPre=/bin/bash -c '/usr/bin/test -f /usr/local/bin/whoamI || /usr/bin/curl -Lo /usr/local/bin/whoamI https://github.com/containous/whoami/releases/download/1.0.0/whoamI'
             ExecStartPre=-/bin/chmod a+x /usr/local/bin/whoamI
             ExecStart=/usr/local/bin/whoamI -port 8000
             [Install]


### PR DESCRIPTION
Point whoamI asset download to new repository location and older version because 1.1.0 binary is missing.